### PR TITLE
add edge for mesh-segmentation

### DIFF
--- a/EXPORT.cue
+++ b/EXPORT.cue
@@ -21,7 +21,8 @@ import (
 	// alias_name "<cue_module>/{path}:<name_of_directory_package>"
 
 	observables "greymatter.io.plus/services/observables:services"
+	edge "greymatter.io.plus/services/edge:services"
 )
 
 configs:
-	observables.ObservablesApp.config
+	observables.ObservablesApp.config + edge.Edge.config

--- a/manifests/edge.svc.yaml
+++ b/manifests/edge.svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-plus
+  namespace: plus
+spec:
+  ports:
+  - name: ingress
+    port: 10809
+    protocol: TCP
+    targetPort: 10809
+  selector:
+    greymatter.io/cluster: edge-plus
+  type: LoadBalancer

--- a/manifests/edge.yaml
+++ b/manifests/edge.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-plus
+  namespace: plus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      greymatter.io/cluster: edge-plus
+  template:
+    metadata:
+      labels:
+        greymatter.io/cluster: edge-plus
+    spec:
+      containers:
+      - env:
+        - name: XDS_CLUSTER
+          value: edge-plus
+        - name: ENVOY_ADMIN_LOG_PATH
+          value: /dev/stdout
+        - name: PROXY_DYNAMIC
+          value: "true"
+        - name: XDS_ZONE
+          value: default-zone
+        - name: XDS_HOST
+          value: controlensemble.greymatter.svc.cluster.local
+        - name: XDS_PORT
+          value: "50000"
+        image: quay.io/greymatterio/gm-proxy:1.7.0
+        imagePullPolicy: Always
+        name: sidecar
+        ports:
+        - containerPort: 10808
+          name: proxy
+          protocol: TCP
+        # volumeMounts:
+        # - mountPath: /etc/proxy/tls/sidecar
+        #   name: tls-certs
+      imagePullSecrets:
+      - name: gm-docker-secret
+      # volumes:
+      # - name: tls-certs
+      #   secret:
+      #     defaultMode: 420
+      #     secretName: gm-edge-ingress-certs

--- a/manifests/namespace.yaml
+++ b/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: plus

--- a/services/edge/edge.cue
+++ b/services/edge/edge.cue
@@ -1,0 +1,61 @@
+// Edge configuration for enterprise mesh-segmentation. This is a dedicated
+// edge proxy that provides north/south network traffic to services in this
+// repository in the mesh. This edge would be separate from the default
+// greymatter.io edge that is deployed via enterprise-level configuration in
+// the gitops-core git repository.
+
+package services
+
+let Name = "edge-plus"
+let EgressToRedisName = "\(Name)_egress_to_redis"
+
+Edge: {
+	name:   Name
+	config: edge_config
+}
+
+edge_config: [
+	#domain & {
+		domain_key:   Name
+		port:         10809
+		_force_https: defaults.enable_edge_tls
+	},
+	#listener & {
+		listener_key:                Name
+		port:                        10809
+		_gm_observables_topic:       Name
+		_is_ingress:                 true
+		_enable_oidc_authentication: false
+		_oidc_endpoint:              defaults.oidc.endpoint
+		_oidc_service_url:           "https://\(defaults.oidc.domain):10808"
+		_oidc_provider:              "\(defaults.oidc.endpoint)/auth/realms/\(defaults.oidc.realm)"
+		_oidc_client_secret:         defaults.oidc.client_secret
+		_oidc_cookie_domain:         defaults.oidc.domain
+		_oidc_realm:                 defaults.oidc.realm
+	},
+	// This cluster must exist (though it never receives traffic)
+	// so that Catalog will be able to look-up edge instances
+	#cluster & {cluster_key: Name},
+
+	// egress->redis
+	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
+	#cluster & {
+		cluster_key:  EgressToRedisName
+		name:         defaults.redis_cluster_name
+		_spire_self:  Name
+		_spire_other: defaults.redis_cluster_name
+	},
+	#route & {route_key: EgressToRedisName},
+	#listener & {
+		listener_key:  EgressToRedisName
+		ip:            "127.0.0.1" // egress listeners are local-only
+		port:          defaults.ports.redis_ingress
+		_tcp_upstream: defaults.redis_cluster_name
+	},
+
+	#proxy & {
+		proxy_key: Name
+		domain_keys: [Name, EgressToRedisName]
+		listener_keys: [Name, EgressToRedisName]
+	},
+]

--- a/services/inputs.cue
+++ b/services/inputs.cue
@@ -27,4 +27,12 @@ defaults: {
 		observables_app_port:      5000
 		egress_elasticsearch_port: 443
 	}
+
+	enable_edge_tls: false
+	oidc: {
+		endpoint:      ""
+		domain:        ""
+		client_secret: ""
+		realm:         ""
+	}
 }

--- a/services/observables/observables_app.cue
+++ b/services/observables/observables_app.cue
@@ -79,7 +79,7 @@ observables_app_config: [
 		listener_keys: [ObservablesAppIngressName, EgressToRedisName, EgressToElasticSearchName]
 	},
 
-	// Edge config for observables_app ingress
+	// Config for greymatter.io edge ingress.
 	#cluster & {
 		cluster_key:  Name
 		_spire_other: Name
@@ -100,7 +100,28 @@ observables_app_config: [
 		prefix_rewrite: "/"
 	},
 
-	// Grey Matter Catalog service entry
+	// Config for edge ingress to support mesh-segmentation.
+	// #cluster & {
+	//  cluster_key:  "\(Name)_edge_plus"
+	//  _spire_other: "\(Name)_edge_plus"
+	// },
+	#route & {
+		domain_key: "edge-plus"
+		route_key:  Name
+		route_match: {
+			path: "/services/observables/"
+		}
+		redirects: [
+			{
+				from:          "^/services/observables$"
+				to:            route_match.path
+				redirect_type: "permanent"
+			},
+		]
+		prefix_rewrite: "/"
+	},
+
+	// Grey Matter Catalog service entry.
 	greymatter.#CatalogService & {
 		name:                      "Observables App"
 		mesh_id:                   mesh.metadata.name


### PR DESCRIPTION
[sc-17308]

This PR adds an edge, so that a user can create a separate north/south ingress to these services. This is an initial step, I still need to test TLS and OIDC, but this works with non-TLS.

You can hit http://EXTERNAL_IP:10809/services/observables. Note that the port is different from the edge setup by gitops-core.