### PR TITLE
annotations needs to be indented into the metadata section

### DIFF
--- a/manifests/observables_deployment.yaml
+++ b/manifests/observables_deployment.yaml
@@ -17,8 +17,8 @@ spec:
       labels:
         app: observables
         greymatter.io/cluster: observables
-    annotations:
-      greymatter.io/inject-sidecar-to: '5000'
+      annotations:
+        greymatter.io/inject-sidecar-to: '5000'
     spec:
       containers:
         - name: service


### PR DESCRIPTION
There is a spacing format issue with the observables app.  The annotation for sidecar injection needs to be indented 2 spaces.