### PR TITLE
fix broken cue string literal

### DIFF
--- a/services/inputs.cue
+++ b/services/inputs.cue
@@ -9,7 +9,7 @@ mesh: {
 		name: string | *"greymatter-mesh"
 	}
 	spec: {
-		zone: string | *"default-zone"
+		zone: string | *"aks-plus-zone"
 		images: {
 			proxy: string | *"quay.io/greymatterio/gm-proxy:1.7.0"
 		}
@@ -27,7 +27,7 @@ defaults: {
 		metrics:                   8081
 		observables_app_port:      5000
 		egress_elasticsearch_port: 443
-		opa_grpc_port:	           9191
+		opa_grpc_port:             9191
 	}
 
 	edge: {

--- a/services/opa/opa.cue
+++ b/services/opa/opa.cue
@@ -24,13 +24,13 @@ opa_config: [
 		_is_ingress:           true
 	},
 	#cluster & {
-        cluster_key: OPAIngressName, 
-        _upstream_port: defaults.ports.opa_grpc_port
-        http2_protocol_options: {
-            allow_connect: true
-        }
-    },
-	#route & {route_key:     OPAIngressName},
+		cluster_key:    OPAIngressName
+		_upstream_port: defaults.ports.opa_grpc_port
+		http2_protocol_options: {
+			allow_connect: true
+		}
+	},
+	#route & {route_key: OPAIngressName},
 
 	// egress->redis
 	#domain & {domain_key: EgressToRedisName, port: defaults.ports.redis_ingress},
@@ -49,7 +49,6 @@ opa_config: [
 		_tcp_upstream: defaults.redis_cluster_name
 	},
 
-
 	// shared proxy object
 	#proxy & {
 		proxy_key: Name
@@ -57,15 +56,13 @@ opa_config: [
 		listener_keys: [OPAIngressName, EgressToRedisName]
 	},
 
-
 	// Grey Matter Catalog service entry.
 	greymatter.#CatalogService & {
 		name:                      "Open Policy Agent"
 		mesh_id:                   mesh.metadata.name
 		service_id:                "opa"
 		version:                   "0.0.1"
-		description:               "A general-purpose policy engine unifying policy enforcement across a cloud 
-native environment"
+		description:               "A general-purpose policy engine unifying policy enforcement across a cloud native environment"
 		api_endpoint:              ""
 		business_impact:           "critical"
 		enable_instance_metrics:   true


### PR DESCRIPTION
@jack-bischoff Please review this fix.

```
cue eval -c EXPORT.cue --out yaml -e configs
import failed: expected label or ':', found 'IDENT' environment:
    ./EXPORT.cue:27:2
    ./services/opa/opa.cue:68:10
```