### PR TITLE
add catalog alias and remove greymatter imports

### DIFF
--- a/greymatter/intermediates.cue
+++ b/greymatter/intermediates.cue
@@ -601,3 +601,5 @@ import (
 		] + input.configs
 	}
 }
+
+#catalogentry: greymatter.#CatalogService

--- a/greymatter/observables/observables_app.cue
+++ b/greymatter/observables/observables_app.cue
@@ -1,9 +1,5 @@
 package greymatter
 
-import (
-	greymatter "greymatter.io/api"
-)
-
 let Name = "observables" // Name needs to match the greymatter.io/cluster value in the Kubernetes deployment
 let ObservablesAppIngressName = "\(Name)_local"
 let EgressToRedisName = "\(Name)_egress_to_redis"
@@ -119,7 +115,7 @@ observables_app_config: [
 	},
 
 	// Grey Matter Catalog service entry.
-	greymatter.#CatalogService & {
+	#catalogentry & {
 		name:                      "Observables App"
 		mesh_id:                   mesh.metadata.name
 		service_id:                "observables"

--- a/greymatter/opa/opa.cue
+++ b/greymatter/opa/opa.cue
@@ -1,9 +1,5 @@
 package greymatter
 
-import (
-	greymatter "greymatter.io/api"
-)
-
 let Name = "opa" // Name needs to match the greymatter.io/cluster value in the Kubernetes deployment
 let OPAIngressName = "\(Name)_local"
 let EgressToRedisName = "\(Name)_egress_to_redis"
@@ -57,7 +53,7 @@ opa_config: [
 	},
 
 	// Grey Matter Catalog service entry.
-	greymatter.#CatalogService & {
+	#catalogentry & {
 		name:                      "Open Policy Agent"
 		mesh_id:                   mesh.metadata.name
 		service_id:                "opa"

--- a/greymatter/ratelimiter/ratelimiter.cue
+++ b/greymatter/ratelimiter/ratelimiter.cue
@@ -1,9 +1,5 @@
 package greymatter
 
-import (
-	greymatter "greymatter.io/api"
-)
-
 let Name = "ratelimit" // Name needs to match the greymatter.io/cluster value in the Kubernetes deployment
 let RateLimitIngressName = "\(Name)_local"
 let EgressToRedisName = "\(Name)_egress_to_redis"
@@ -53,7 +49,7 @@ ratelimit_config: [
 	},
 
 	// Grey Matter Catalog service entry
-	greymatter.#CatalogService & {
+	#catalogentry & {
 		name:                      "Rate Limit Service"
 		mesh_id:                   mesh.metadata.name
 		service_id:                "ratelimit"


### PR DESCRIPTION
This removes the need for users to import the greymatter library into their service files just for catalog. All other objects are aliased and this continues that pattern. fixes [sc-21310]
Signed-off-by: Alec Holmes <alecholmez@me.com>